### PR TITLE
FlutterConf LATAM - Nuevas Paginas

### DIFF
--- a/lib/features/cfp/presentation/pages/cfp_page.dart
+++ b/lib/features/cfp/presentation/pages/cfp_page.dart
@@ -1,15 +1,77 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_conf_colombia/features/cfp/presentation/responsiveness/cfp_page_responsive_config.dart';
+import 'package:flutter_conf_colombia/features/shared/widgets/circleround_iconbutton.dart';
+import 'package:flutter_conf_colombia/helpers/utils.dart';
+import 'package:flutter_conf_colombia/styles/colors.dart';
+import 'package:flutter_conf_colombia/styles/flutter_conf_latam_icons_icons.dart';
+import 'package:flutter_conf_colombia/styles/styles.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class CFPPage extends StatelessWidget {
+class CFPPage extends ConsumerWidget {
 
   static const String route = '/cfp';
 
   const CFPPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Text('CFP'),
+  Widget build(BuildContext context, WidgetRef ref) {
+
+    final uiConfig = CfpPageResponsiveConfig.getCfpPageResponsiveConfig(context);
+
+    return SingleChildScrollView(
+      child: Center(
+        child: Padding(
+          padding: uiConfig.pagePadding,
+          child: Column(
+            children: [
+              Flex(
+                direction: uiConfig.headerDirection,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    FlutterConfLatamIcons.speaker, 
+                    size: uiConfig.headerIconSize, 
+                    color: FlutterLatamColors.blueText,
+                  ),
+                  uiConfig.headerGap,
+                  Text('Call For Papers', 
+                    textAlign: TextAlign.center, style: uiConfig.headerStyle,
+                  ),
+                ],
+              ),
+              uiConfig.pageVerticalGap,
+              Text("The speakers at FlutterConf LATAM are a critical part in building a high energy event and encouraging discussions in the most important and interesting areas of Flutter. Please submit a paper if you have a new, exciting point of view or experience to share, if you want to actively collaborate on best practices, and if you're a fun personality that should be in front of the awesome FlutterConf LATAM audience. Please note, all presentations are live, in person, in Medellin, Colombia. (Funding is available to assist with travel.) Please share information about Flutter Heroes call for papers with your network - we want to reach deep within the community and build a diverse program that benefits all Flutter developers.",
+                textAlign: TextAlign.center,
+              ),
+              uiConfig.pageVerticalGap,
+              Text('Call for Papers Deadline', textAlign: TextAlign.center, style: uiConfig.deadlineHeaderStyle.copyWith(color: FlutterLatamColors.lightBlue)),
+              Text('October 25th & 26th, 2023', textAlign: TextAlign.center, style: uiConfig.subheaderStyle),
+              uiConfig.pageVerticalGap,
+              CircleRoundIconButton(
+                icon: FlutterConfLatamIcons.speaker,
+                label: 'Submit your CFP',
+                iconColor: Colors.white,
+                backgroundColor: FlutterLatamColors.lightBlue,
+                labelColor: Colors.white,
+                circleColor: FlutterLatamColors.darkBlue,
+                labelWeight: FontWeight.bold,
+                fontSize: uiConfig.cfpButtonLabelSize,
+                iconSize: uiConfig.cfpButtonIconSize,
+                iconPadding: uiConfig.cfpButtonIconPadding,
+                onTap: () {
+                  Utils.launchUrlLink('');
+                },
+              ),
+            ].animate(
+              interval: 50.ms,
+            ).slideY(
+              begin: 1, end: 0,
+              curve: Curves.easeInOut,
+            ).fadeIn(),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/cfp/presentation/responsiveness/cfp_page_responsive_config.dart
+++ b/lib/features/cfp/presentation/responsiveness/cfp_page_responsive_config.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_conf_colombia/styles/styles.dart';
+import 'package:responsive_builder/responsive_builder.dart';
+
+class CfpPageResponsiveConfig {
+  const CfpPageResponsiveConfig({
+    required this.pagePadding,
+    required this.headerStyle,
+    required this.deadlineHeaderStyle,
+    required this.subheaderStyle,
+    required this.headerDirection,
+    required this.headerGap,
+    required this.headerIconSize,
+    required this.pageVerticalGap,
+    required this.cfpButtonIconSize,
+    required this.cfpButtonLabelSize,
+    required this.cfpButtonIconPadding,
+    required this.ticketButtonMargin,
+});
+
+
+  final EdgeInsets pagePadding;
+  final TextStyle headerStyle;
+  final TextStyle deadlineHeaderStyle;
+  final TextStyle subheaderStyle;
+  final Axis headerDirection;
+  final double headerIconSize;
+  final SizedBox headerGap;
+  final SizedBox pageVerticalGap;
+  final double cfpButtonIconSize;
+  final double cfpButtonLabelSize;
+  final double cfpButtonIconPadding;
+  final double ticketButtonMargin;
+
+  static CfpPageResponsiveConfig getCfpPageResponsiveConfig(BuildContext ctxt) {
+    final config = getValueForScreenType(
+      context: ctxt,
+      mobile: const CfpPageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.largePadding,
+        headerGap: FlutterConfLatamStyles.smallVGap,
+        headerStyle: FlutterConfLatamStyles.h2,
+        deadlineHeaderStyle: FlutterConfLatamStyles.h6,
+        subheaderStyle: FlutterConfLatamStyles.h4,
+        headerDirection: Axis.vertical,
+        headerIconSize: 60,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+        cfpButtonIconSize: 20,
+        cfpButtonLabelSize: 20,
+        cfpButtonIconPadding: 15,
+        ticketButtonMargin: 15,
+      ),
+      tablet: const CfpPageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.mediumPadding,
+        headerStyle: FlutterConfLatamStyles.h2,
+        subheaderStyle: FlutterConfLatamStyles.h3,
+        deadlineHeaderStyle: FlutterConfLatamStyles.h5,
+        headerGap: FlutterConfLatamStyles.smallHGap,
+        headerDirection: Axis.horizontal,
+        headerIconSize: 60,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+        cfpButtonIconSize: 30,
+        cfpButtonLabelSize: 20,
+        cfpButtonIconPadding: 20,
+        ticketButtonMargin: 20,
+      ),
+      desktop: const CfpPageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.xLargePadding,
+        headerStyle: FlutterConfLatamStyles.h1,
+        subheaderStyle: FlutterConfLatamStyles.h3,
+        deadlineHeaderStyle: FlutterConfLatamStyles.h5,
+        headerGap: FlutterConfLatamStyles.smallHGap,
+        headerDirection: Axis.horizontal,
+        headerIconSize: 80,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+        cfpButtonIconSize: 30,
+        cfpButtonLabelSize: 20,
+        cfpButtonIconPadding: 20,
+        ticketButtonMargin: 20,
+      ),
+    );
+
+    return config;
+  }
+}

--- a/lib/features/contact/presentation/pages/contact.page.dart
+++ b/lib/features/contact/presentation/pages/contact.page.dart
@@ -1,15 +1,91 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_conf_colombia/features/contact/presentation/responsiveness/contact_page_responsive_config.dart';
+import 'package:flutter_conf_colombia/styles/colors.dart';
+import 'package:flutter_conf_colombia/styles/styles.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class ContactPage extends StatelessWidget {
+class ContactPage extends ConsumerWidget {
 
   static const String route = '/contact';
 
   const ContactPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Text('Contact'),
+  Widget build(BuildContext context, WidgetRef ref) {
+
+    final uiConfig = ContactPageResponsiveConfig.getContactPageResponsiveConfig(context);
+
+    return SingleChildScrollView(
+      child: Center(
+        child: Padding(
+          padding: uiConfig.pagePadding,
+          child: Column(
+            children: [
+              Flex(
+                direction: uiConfig.headerDirection,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.account_circle,
+                    size: uiConfig.headerIconSize, color: FlutterLatamColors.blueText,
+                  ),
+                  uiConfig.headerGap,
+                  Text('Contact', 
+                    textAlign: TextAlign.center, 
+                    style: uiConfig.headerStyle,
+                  ),
+                ],
+              ),
+              uiConfig.pageVerticalGap,
+              Text('Get in touch with the FlutterConf LATAM Team!', textAlign: TextAlign.center,
+                style: uiConfig.subheaderStyle
+              ),
+              uiConfig.pageVerticalGap,
+              Text("Would you like to reach out to us? If you have any questions related to anything regarding FlutterConf LATAM,\nplease do not hesitate to reach out to us via email by clicking on the link below, or by reaching us through social media!",
+                textAlign: TextAlign.center,
+              ),
+              uiConfig.pageVerticalGap,
+              MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  onTap: () {
+                    
+                  },
+                  child: Container(
+                    margin: uiConfig.contactInfoMargin,
+                    padding: uiConfig.contactInfoPadding,
+                    child: Flex(
+                      direction: uiConfig.contactInfoDirection,
+                      mainAxisSize: MainAxisSize.min,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.email, color: FlutterLatamColors.lightBlue, size: uiConfig.contactInfoIconSize),
+                        FlutterConfLatamStyles.smallHGap,
+                        Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: uiConfig.contactInfoAlignment,
+                          children: [
+                            Text("Send Us Email at", style: uiConfig.contactInfoStyle.copyWith(color: FlutterLatamColors.lightBlue, fontWeight: FontWeight.normal)),
+                            Text("flutterconflatam@gmail.com", style: uiConfig.contactInfoStyle.copyWith(color: FlutterLatamColors.lightBlue)),
+                          ],
+                        )
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              
+              uiConfig.pageVerticalGap,
+            ].animate(
+              interval: 50.ms,
+            ).slideY(
+              begin: 1, end: 0,
+              curve: Curves.easeInOut,
+            ).fadeIn(),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/contact/presentation/responsiveness/contact_page_responsive_config.dart
+++ b/lib/features/contact/presentation/responsiveness/contact_page_responsive_config.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_conf_colombia/styles/styles.dart';
+import 'package:responsive_builder/responsive_builder.dart';
+
+class ContactPageResponsiveConfig {
+  const ContactPageResponsiveConfig({
+    required this.pagePadding,
+    required this.headerStyle,
+    required this.subheaderStyle,
+    required this.headerDirection,
+    required this.headerGap,
+    required this.headerIconSize,
+    required this.pageVerticalGap,
+    required this.contactInfoDirection,
+    required this.contactInfoIconSize,
+    required this.contactInfoStyle,
+    required this.contactInfoPadding,
+    required this.contactInfoMargin,
+    required this.contactInfoAlignment,
+});
+
+
+  final EdgeInsets pagePadding;
+  final TextStyle headerStyle;
+  final TextStyle subheaderStyle;
+  final TextStyle contactInfoStyle;
+  final Axis headerDirection;
+  final double headerIconSize;
+  final SizedBox headerGap;
+  final SizedBox pageVerticalGap;
+  final double contactInfoIconSize;
+  final Axis contactInfoDirection;
+  final EdgeInsets contactInfoPadding;
+  final EdgeInsets contactInfoMargin;
+  final CrossAxisAlignment contactInfoAlignment;
+
+
+  static ContactPageResponsiveConfig getContactPageResponsiveConfig(BuildContext ctxt) {
+    final config = getValueForScreenType(
+      context: ctxt,
+      mobile: const ContactPageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.largePadding,
+        headerGap: FlutterConfLatamStyles.smallVGap,
+        headerStyle: FlutterConfLatamStyles.h2,
+        contactInfoStyle: FlutterConfLatamStyles.h7,
+        subheaderStyle: FlutterConfLatamStyles.h5,
+        headerDirection: Axis.vertical,
+        headerIconSize: 60,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+        contactInfoIconSize: 40,
+        contactInfoDirection: Axis.vertical,
+        contactInfoPadding: FlutterConfLatamStyles.smallPadding,
+        contactInfoMargin: FlutterConfLatamStyles.smallMargin,
+        contactInfoAlignment: CrossAxisAlignment.center,
+      ),
+      tablet: const ContactPageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.mediumPadding,
+        headerStyle: FlutterConfLatamStyles.h2,
+        subheaderStyle: FlutterConfLatamStyles.h5,
+        headerGap: FlutterConfLatamStyles.smallHGap,
+        headerDirection: Axis.horizontal,
+        headerIconSize: 60,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+        contactInfoStyle: FlutterConfLatamStyles.h6,
+        contactInfoDirection: Axis.horizontal,
+        contactInfoIconSize: 80,
+        contactInfoPadding: FlutterConfLatamStyles.mediumPadding,
+        contactInfoMargin: FlutterConfLatamStyles.mediumMargin,
+        contactInfoAlignment: CrossAxisAlignment.start,
+      ),
+      desktop: const ContactPageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.xLargePadding,
+        headerStyle: FlutterConfLatamStyles.h1,
+        subheaderStyle: FlutterConfLatamStyles.h4,
+        headerGap: FlutterConfLatamStyles.smallHGap,
+        headerDirection: Axis.horizontal,
+        headerIconSize: 80,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+        contactInfoIconSize: 100,
+        contactInfoStyle: FlutterConfLatamStyles.h5,
+        contactInfoDirection: Axis.horizontal,
+        contactInfoPadding: FlutterConfLatamStyles.mediumPadding,
+        contactInfoMargin: FlutterConfLatamStyles.mediumMargin,
+        contactInfoAlignment: CrossAxisAlignment.start,
+      ),
+    );
+
+    return config;
+  }
+}

--- a/lib/features/navigation/data/models/tab_navigation_item.dart
+++ b/lib/features/navigation/data/models/tab_navigation_item.dart
@@ -4,21 +4,25 @@ class TabNavigationItem {
     required this.label,
     required this.route,
     this.isSelected = false,
+    this.display = true,
   });
 
   final String label;
   final String route;
   final bool? isSelected;
+  final bool? display;
 
   TabNavigationItem copyWith({
       String? label,
       String? route,
-      bool? isSelected
+      bool? isSelected,
+      bool? display,
     }) {
       return TabNavigationItem(
         label: label ?? this.label, 
         route: route ?? this.route,
-        isSelected: isSelected ?? this.isSelected 
+        isSelected: isSelected ?? this.isSelected,
+        display: display ?? this.display,
     );
   }
 }

--- a/lib/features/navigation/data/repositories/navigation.repository.dart
+++ b/lib/features/navigation/data/repositories/navigation.repository.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_conf_colombia/features/cfp/presentation/pages/cfp_page.dart';
+import 'package:flutter_conf_colombia/features/contact/presentation/pages/contact.page.dart';
 import 'package:flutter_conf_colombia/features/home/presentation/pages/home_page.dart';
 import 'package:flutter_conf_colombia/features/navigation/data/models/tab_navigation_item.dart';
+import 'package:flutter_conf_colombia/features/schedule/presentation/pages/schedule_page.dart';
 import 'package:flutter_conf_colombia/features/speakers/presentation/pages/speakers_page.dart';
 import 'package:flutter_conf_colombia/features/sponsors/presentation/pages/sponsors_page.dart';
 import 'package:flutter_conf_colombia/features/tickets/presentation/pages/tickets_page.dart';
@@ -22,12 +24,13 @@ class NavigationRepository {
       TabNavigationItem(
         label: appLoc.home,
         route: HomePage.route,
-        isSelected: true
+        isSelected: true,
+        display: false,
       ),
-      TabNavigationItem(
-        label: appLoc.cfp,
-        route: CFPPage.route,
-      ),
+      // TabNavigationItem(
+      //   label: appLoc.cfp,
+      //   route: CFPPage.route,
+      // ),
       TabNavigationItem(
         label: appLoc.tickets,
         route: TicketsPage.route,
@@ -39,7 +42,14 @@ class NavigationRepository {
       TabNavigationItem(
         label: appLoc.sponsors,
         route: SponsorsPage.route,
-
+      ),
+      TabNavigationItem(
+        label: appLoc.schedule,
+        route: SchedulePage.route,
+      ),
+      TabNavigationItem(
+        label: appLoc.contact,
+        route: ContactPage.route,
       )
     ];
   }

--- a/lib/features/navigation/presentation/viewmodels/navigation.viewmodel.dart
+++ b/lib/features/navigation/presentation/viewmodels/navigation.viewmodel.dart
@@ -19,7 +19,12 @@ class NavigationViewModel extends StateNotifier<List<TabNavigationItem>> {
 
     state = [
       for (var element in state)
-       element.copyWith(isSelected: item == element)
+       element.copyWith(isSelected: item == element,)
     ];
+  }
+
+  void selectNavItemFromRoute(String route) {
+    final routeItem = state.where((i) => i.route == route).first;
+    selectNavItem(routeItem);
   }
 }

--- a/lib/features/navigation/presentation/widgets/footer.dart
+++ b/lib/features/navigation/presentation/widgets/footer.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_conf_colombia/features/home/presentation/pages/home_page.dart';
+import 'package:flutter_conf_colombia/features/navigation/presentation/providers/navigation_providers.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/responsiveness/navigation_responsive_config.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/widgets/social_media_container.dart';
 import 'package:flutter_conf_colombia/helpers/constants.dart';
@@ -19,29 +21,38 @@ class Footer extends ConsumerWidget {
     Widget socialNetworks() => const SocialMediaContainer();
 
     Widget copyright() => Center(
-          child: Text(
-            appLoc.copyright,
-            style: const TextStyle(
-              color: Colors.grey,
-            ),
-          ),
-        );
+      child: Text(
+        appLoc.copyright,
+        style: const TextStyle(
+          color: Colors.grey,
+        ),
+      ),
+    );
 
-    Widget flutterConfLogo() => Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        const Icon(
-          FlutterConfLatamIcons.flutteconflatam_text,
-          size: 40,
-          color: Colors.white,
+    Widget flutterConfLogo() => 
+    MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () {
+          ref.read(navigationItemsProvider.notifier).selectNavItemFromRoute(HomePage.route);
+        },
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              FlutterConfLatamIcons.flutteconflatam_text,
+              size: 40,
+              color: Colors.white,
+            ),
+            const SizedBox(width: 15.0),
+            SvgPicture.asset(
+              '${Constants.imagesPath}/FlutterLogo_White.svg',
+              width: 40,
+              height: 40,
+            ),
+          ],
         ),
-        const SizedBox(width: 15.0),
-        SvgPicture.asset(
-          '${Constants.imagesPath}/FlutterLogo_White.svg',
-          width: 40,
-          height: 40,
-        ),
-      ],
+      ),
     );
 
     return ColoredBox(

--- a/lib/features/navigation/presentation/widgets/header.dart
+++ b/lib/features/navigation/presentation/widgets/header.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_conf_colombia/features/home/presentation/pages/home_page.dart';
 import 'package:flutter_conf_colombia/features/home/presentation/widgets/custom_tab_controller.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/providers/navigation_providers.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/responsiveness/navigation_responsive_config.dart';
@@ -6,7 +7,6 @@ import 'package:flutter_conf_colombia/features/navigation/presentation/widgets/l
 import 'package:flutter_conf_colombia/features/shared/widgets/animations/flutter_logo_animated.dart';
 import 'package:flutter_conf_colombia/styles/colors.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 class Header extends ConsumerStatefulWidget {
 
@@ -25,6 +25,7 @@ class HeaderState extends ConsumerState<Header> with TickerProviderStateMixin {
     
     final uiConfig = NavigationResponsiveConfig.getNavigationConfig(context);
     final tabItems = ref.watch(navigationItemsProvider);
+    final visibleTabItems = tabItems.where((t) => t.display!).toList();
 
     return SliverAppBar(
       backgroundColor: Colors.white,
@@ -57,7 +58,15 @@ class HeaderState extends ConsumerState<Header> with TickerProviderStateMixin {
                   ),
                   width: currentWidth,
                   height: currentHeight,
-                  child: const FlutterLogoAnimated(),
+                  child: MouseRegion(
+                    cursor: SystemMouseCursors.click,
+                    child: GestureDetector(
+                      onTap: () {
+                        ref.read(navigationItemsProvider.notifier).selectNavItemFromRoute(HomePage.route);
+                      },
+                      child: const FlutterLogoAnimated(),
+                    ),
+                  ),
                 );
               },
             ),
@@ -66,22 +75,22 @@ class HeaderState extends ConsumerState<Header> with TickerProviderStateMixin {
             alignment: Alignment.bottomCenter,
             child: TabBar(
               onTap: (index) {
-                // 
-                ref.read(navigationItemsProvider.notifier).selectNavItem(tabItems[index]);
+                final navItem = visibleTabItems[index];
+                ref.read(navigationItemsProvider.notifier).selectNavItem(navItem);
               },
-              controller: CustomTabController(length: tabItems.length, vsync: this).build(),
+              controller: CustomTabController(length: visibleTabItems.length, vsync: this).build(),
               isScrollable: true,
               indicatorWeight: 1.0,
               indicatorColor: Colors.white,
               labelColor: FlutterLatamColors.darkBlue,
               unselectedLabelColor: Colors.grey,
               tabs: [
-                for (final tabItem in tabItems)
+                for (final tabItem in visibleTabItems)
                   Tab(
                     child: Text(
                       tabItem.label,
                       style: TextStyle(
-                        color: tabItem.isSelected! ? FlutterLatamColors.darkBlue : Colors.grey)
+                        color: tabItem.isSelected! ? FlutterLatamColors.darkBlue : Colors.grey),
                     ),
                   ),
               ],

--- a/lib/features/navigation/presentation/widgets/mobile_drawer.dart
+++ b/lib/features/navigation/presentation/widgets/mobile_drawer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_conf_colombia/features/home/data/models/home_section.dart';
+import 'package:flutter_conf_colombia/features/home/presentation/pages/home_page.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/providers/navigation_providers.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/widgets/item_drawer.dart';
 import 'package:flutter_conf_colombia/helpers/constants.dart';
@@ -16,6 +17,7 @@ class MobileDrawer extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
 
     final tabItems = ref.watch(navigationItemsProvider);
+    final visibleTabItems = tabItems.where((t) => t.display!).toList();
 
     return Drawer(
       backgroundColor: Colors.blue,
@@ -29,11 +31,20 @@ class MobileDrawer extends ConsumerWidget {
           children: [
             Row(
               children: [
-                Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: SvgPicture.asset('${Constants.imagesPath}/FlutterLogo_White.svg',
-                    width: 80,
-                    height: 80,
+                MouseRegion(
+                  cursor: SystemMouseCursors.click,
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      ref.read(navigationItemsProvider.notifier).selectNavItemFromRoute(HomePage.route);
+                    },
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: SvgPicture.asset('${Constants.imagesPath}/FlutterLogo_White.svg',
+                        width: 80,
+                        height: 80,
+                      ),
+                    ),
                   ),
                 ),
               ],
@@ -41,9 +52,9 @@ class MobileDrawer extends ConsumerWidget {
             Expanded(
               child: Column(
                 children: [
-                  for (var i = 0; i < tabItems.length; i++)
+                  for (var i = 0; i < visibleTabItems.length; i++)
                     ItemDrawer(
-                      item: tabItems[i]
+                      item: visibleTabItems[i],
                     ),
                 ],
               ),

--- a/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -1,15 +1,61 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_conf_colombia/features/schedule/presentation/responsiveness/schedule_page_responsive_config.dart';
+import 'package:flutter_conf_colombia/features/shared/widgets/comingsoon_container.dart';
+import 'package:flutter_conf_colombia/styles/colors.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class SchedulePage extends StatelessWidget {
+class SchedulePage extends ConsumerWidget {
 
   static const String route = '/schedule';
 
   const SchedulePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Text('Schedule'),
+  Widget build(BuildContext context, WidgetRef ref) {
+
+    final uiConfig = SchedulePageResponsiveConfig.getSchedulePageResponsiveConfig(context);
+
+    return SingleChildScrollView(
+      child: Center(
+        child: Padding(
+          padding: uiConfig.pagePadding,
+          child: Column(
+            children: [
+              Flex(
+                direction: uiConfig.headerDirection,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.calendar_today,
+                    size: uiConfig.headerIconSize, color: FlutterLatamColors.blueText,
+                  ),
+                  uiConfig.headerGap,
+                  Text('Schedule', 
+                    textAlign: TextAlign.center, 
+                    style: uiConfig.headerStyle,
+                  ),
+                ],
+              ),
+              uiConfig.pageVerticalGap,
+              Text("We are putting together an amazing agenda for you to enjoy and learn, full of great technical Flutter talks, imparted by a top-notch line-up of speakers at the top of their game!",
+                textAlign: TextAlign.center,
+              ),
+              uiConfig.pageVerticalGap,
+              Text('PLEASE CHECK BACK AGAIN SOON WHEN WE WILL HAVE THE FULL SCHEDULE AVAILABLE', textAlign: TextAlign.center,
+                style: uiConfig.subheaderStyle
+              ),
+              uiConfig.pageVerticalGap,
+              ComingSoonContainer()
+            ].animate(
+              interval: 50.ms,
+            ).slideY(
+              begin: 1, end: 0,
+              curve: Curves.easeInOut,
+            ).fadeIn(),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/schedule/presentation/responsiveness/schedule_page_responsive_config.dart
+++ b/lib/features/schedule/presentation/responsiveness/schedule_page_responsive_config.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_conf_colombia/styles/styles.dart';
+import 'package:responsive_builder/responsive_builder.dart';
+
+class SchedulePageResponsiveConfig {
+  const SchedulePageResponsiveConfig({
+    required this.pagePadding,
+    required this.headerStyle,
+    required this.subheaderStyle,
+    required this.headerDirection,
+    required this.headerGap,
+    required this.headerIconSize,
+    required this.pageVerticalGap,
+});
+
+
+  final EdgeInsets pagePadding;
+  final TextStyle headerStyle;
+  final TextStyle subheaderStyle;
+  final Axis headerDirection;
+  final double headerIconSize;
+  final SizedBox headerGap;
+  final SizedBox pageVerticalGap;
+
+
+  static SchedulePageResponsiveConfig getSchedulePageResponsiveConfig(BuildContext ctxt) {
+    final config = getValueForScreenType(
+      context: ctxt,
+      mobile: const SchedulePageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.largePadding,
+        headerGap: FlutterConfLatamStyles.smallVGap,
+        headerStyle: FlutterConfLatamStyles.h2,
+        subheaderStyle: FlutterConfLatamStyles.h6,
+        headerDirection: Axis.vertical,
+        headerIconSize: 60,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+      ),
+      tablet: const SchedulePageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.mediumPadding,
+        headerStyle: FlutterConfLatamStyles.h2,
+        subheaderStyle: FlutterConfLatamStyles.h5,
+        headerGap: FlutterConfLatamStyles.smallHGap,
+        headerDirection: Axis.horizontal,
+        headerIconSize: 60,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+      ),
+      desktop: const SchedulePageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.xLargePadding,
+        headerStyle: FlutterConfLatamStyles.h1,
+        subheaderStyle: FlutterConfLatamStyles.h4,
+        headerGap: FlutterConfLatamStyles.smallHGap,
+        headerDirection: Axis.horizontal,
+        headerIconSize: 80,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+      ),
+    );
+
+    return config;
+  }
+}

--- a/lib/features/shellpage/shell.page.dart
+++ b/lib/features/shellpage/shell.page.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_conf_colombia/features/home/presentation/pages/home_page.dart';
+import 'package:flutter_conf_colombia/features/navigation/presentation/providers/navigation_providers.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/widgets/footer.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/widgets/header.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/widgets/language_button.dart';
 import 'package:flutter_conf_colombia/features/navigation/presentation/widgets/mobile_drawer.dart';
 import 'package:flutter_conf_colombia/helpers/constants.dart';
 import 'package:flutter_conf_colombia/helpers/utils.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:responsive_builder/responsive_builder.dart';
 
-class ShellPage extends StatelessWidget {
+class ShellPage extends ConsumerWidget {
 
   static const String route = '/main';
   final Widget child;
@@ -19,7 +22,7 @@ class ShellPage extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
 
     final isMobile = getValueForScreenType(
       context: context,
@@ -32,10 +35,18 @@ class ShellPage extends StatelessWidget {
       key: Utils.mainScaffold,
       appBar: isMobile
           ? AppBar(
-              title: SvgPicture.asset(
-                '${Constants.imagesPath}/flutter_logo_color.svg',
-                width: 40,
-                height: 40,
+              title: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  onTap: () {
+                    ref.read(navigationItemsProvider.notifier).selectNavItemFromRoute(HomePage.route);
+                  },
+                  child: SvgPicture.asset(
+                    '${Constants.imagesPath}/flutter_logo_color.svg',
+                    width: 40,
+                    height: 40,
+                  ),
+                ),
               ),
               actions: const [
                 LanguageButton()

--- a/lib/features/tickets/presentation/pages/tickets_page.dart
+++ b/lib/features/tickets/presentation/pages/tickets_page.dart
@@ -1,15 +1,78 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_conf_colombia/features/shared/widgets/circleround_iconbutton.dart';
+import 'package:flutter_conf_colombia/features/shared/widgets/comingsoon_container.dart';
+import 'package:flutter_conf_colombia/features/tickets/presentation/responsiveness/ticket_page_responsive_config.dart';
+import 'package:flutter_conf_colombia/styles/colors.dart';
+import 'package:flutter_conf_colombia/styles/flutter_conf_latam_icons_icons.dart';
+import 'package:flutter_conf_colombia/styles/styles.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class TicketsPage extends StatelessWidget {
+class TicketsPage extends ConsumerWidget {
 
   static const String route = '/tickets';
 
   const TicketsPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Text('Tickets'),
+  Widget build(BuildContext context, WidgetRef ref) {
+
+    final uiConfig = TicketPageResponsiveConfig.getTicketPageResponsiveConfig(context);
+
+    return SingleChildScrollView(
+      child: Center(
+        child: Padding(
+          padding: uiConfig.pagePadding,
+          child: Column(
+            children: [
+              Flex(
+                direction: uiConfig.headerDirection,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    FlutterConfLatamIcons.ticket,
+                    size: uiConfig.headerIconSize, color: FlutterLatamColors.blueText,
+                  ),
+                  uiConfig.headerGap,
+                  Text('Tickets', 
+                    textAlign: TextAlign.center, 
+                    style: uiConfig.headerStyle,
+                  ),
+                ],
+              ),
+              uiConfig.pageVerticalGap,
+              Text("Curtain up for FlutterConf LATAM '23, which will take place in 2023 in the iconic city of Medellin, in Colombia. Two full days of multiple tracks with in-depth tech talks, workshops, panels, and more. A place where Flutter & Dart experts, GDEs, & hundreds of FlutterDevs will converge in one single place. Your ticket grants access to FlutterConf LATAM 2023.",
+                textAlign: TextAlign.center,
+              ),
+              uiConfig.pageVerticalGap,
+              Text('PLEASE CHECK BACK AGAIN SOON WHEN WE WILL HAVE THE TICKET PURCHASE SYSTEM AVAILABLE!', textAlign: TextAlign.center,
+                style: uiConfig.subheaderStyle
+              ),
+              uiConfig.pageVerticalGap,
+              CircleRoundIconButton(
+                icon: FlutterConfLatamIcons.ticket,
+                label: 'Buy your Ticket',
+                iconColor: Colors.white,
+                backgroundColor: FlutterLatamColors.lightBlue,
+                labelColor: Colors.white,
+                circleColor: FlutterLatamColors.darkBlue,
+                labelWeight: FontWeight.bold,
+                fontSize: uiConfig.ticketButtonLabelSize,
+                iconSize: uiConfig.ticketButtonIconSize,
+                iconPadding: uiConfig.ticketButtonIconPadding,
+                onTap: null,
+              ),
+              FlutterConfLatamStyles.mediumVGap,
+              const ComingSoonContainer(),
+            ].animate(
+              interval: 50.ms,
+            ).slideY(
+              begin: 1, end: 0,
+              curve: Curves.easeInOut,
+            ).fadeIn(),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/tickets/presentation/responsiveness/ticket_banner_responsive_config.dart
+++ b/lib/features/tickets/presentation/responsiveness/ticket_banner_responsive_config.dart
@@ -16,7 +16,7 @@ class TicketBannerResponsiveConfig {
     required this.ticketButtonMargin, 
     required this.ticketButtonAlignment, 
     required this.ticketButtonColumnCrossAxis, 
-    required this.ticketButtonColumnMainAxis   
+    required this.ticketButtonColumnMainAxis,
 });
 
 

--- a/lib/features/tickets/presentation/responsiveness/ticket_page_responsive_config.dart
+++ b/lib/features/tickets/presentation/responsiveness/ticket_page_responsive_config.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_conf_colombia/styles/styles.dart';
+import 'package:responsive_builder/responsive_builder.dart';
+
+class TicketPageResponsiveConfig {
+  const TicketPageResponsiveConfig({
+    required this.pagePadding,
+    required this.headerStyle,
+    required this.subheaderStyle,
+    required this.headerDirection,
+    required this.headerGap,
+    required this.headerIconSize,
+    required this.pageVerticalGap,
+    required this.ticketButtonIconSize,
+    required this.ticketButtonLabelSize,
+    required this.ticketButtonIconPadding,
+    required this.ticketButtonMargin,
+});
+
+
+  final EdgeInsets pagePadding;
+  final TextStyle headerStyle;
+  final TextStyle subheaderStyle;
+  final Axis headerDirection;
+  final double headerIconSize;
+  final SizedBox headerGap;
+  final SizedBox pageVerticalGap;
+  final double ticketButtonIconSize;
+  final double ticketButtonLabelSize;
+  final double ticketButtonIconPadding;
+  final double ticketButtonMargin;
+
+  static TicketPageResponsiveConfig getTicketPageResponsiveConfig(BuildContext ctxt) {
+    final config = getValueForScreenType(
+      context: ctxt,
+      mobile: const TicketPageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.largePadding,
+        headerGap: FlutterConfLatamStyles.smallVGap,
+        headerStyle: FlutterConfLatamStyles.h2,
+        subheaderStyle: FlutterConfLatamStyles.h6,
+        headerDirection: Axis.vertical,
+        headerIconSize: 60,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+        ticketButtonIconSize: 20,
+        ticketButtonLabelSize: 20,
+        ticketButtonIconPadding: 15,
+        ticketButtonMargin: 15,
+      ),
+      tablet: const TicketPageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.mediumPadding,
+        headerStyle: FlutterConfLatamStyles.h2,
+        subheaderStyle: FlutterConfLatamStyles.h5,
+        headerGap: FlutterConfLatamStyles.smallHGap,
+        headerDirection: Axis.horizontal,
+        headerIconSize: 60,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+        ticketButtonIconSize: 30,
+        ticketButtonLabelSize: 20,
+        ticketButtonIconPadding: 20,
+        ticketButtonMargin: 20,
+      ),
+      desktop: const TicketPageResponsiveConfig(
+        pagePadding: FlutterConfLatamStyles.xLargePadding,
+        headerStyle: FlutterConfLatamStyles.h1,
+        subheaderStyle: FlutterConfLatamStyles.h4,
+        headerGap: FlutterConfLatamStyles.smallHGap,
+        headerDirection: Axis.horizontal,
+        headerIconSize: 80,
+        pageVerticalGap: FlutterConfLatamStyles.mediumVGap,
+        ticketButtonIconSize: 30,
+        ticketButtonLabelSize: 20,
+        ticketButtonIconPadding: 20,
+        ticketButtonMargin: 20,
+      ),
+    );
+
+    return config;
+  }
+}

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_conf_colombia/features/cfp/presentation/pages/cfp_page.dart';
+import 'package:flutter_conf_colombia/features/contact/presentation/pages/contact.page.dart';
 import 'package:flutter_conf_colombia/features/errors/presentation/pages/error.page.dart';
 import 'package:flutter_conf_colombia/features/home/presentation/pages/home_page.dart';
+import 'package:flutter_conf_colombia/features/schedule/presentation/pages/schedule_page.dart';
 import 'package:flutter_conf_colombia/features/shellpage/shell.page.dart';
 import 'package:flutter_conf_colombia/features/speakers/presentation/pages/speakers_page.dart';
 import 'package:flutter_conf_colombia/features/splash/presentation/pages/splash.page.dart';
@@ -70,9 +72,27 @@ class AppRoutes {
             parentNavigatorKey: Utils.tabNav,
             path: SponsorsPage.route,
             pageBuilder: (context, state) {
-                return const NoTransitionPage(
-                  child: SponsorsPage(),
-                );
+              return const NoTransitionPage(
+                child: SponsorsPage(),
+              );
+            },
+          ),
+          GoRoute(
+            parentNavigatorKey: Utils.tabNav,
+            path: SchedulePage.route,
+            pageBuilder: (context, state) {
+              return const NoTransitionPage(
+                child: SchedulePage(),
+              );
+            },
+          ),
+          GoRoute(
+            parentNavigatorKey: Utils.tabNav,
+            path: ContactPage.route,
+            pageBuilder: (context, state) {
+              return const NoTransitionPage(
+                child: ContactPage(),
+              );
             },
           ),
         ]

--- a/lib/styles/styles.dart
+++ b/lib/styles/styles.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_conf_colombia/styles/colors.dart';
 
 class FlutterConfLatamStyles {
 
@@ -23,4 +24,14 @@ class FlutterConfLatamStyles {
   static const EdgeInsets largeMargin = EdgeInsets.all(32);
   static const EdgeInsets xLargeMargin = EdgeInsets.all(64);
   static const EdgeInsets xxLargeMargin = EdgeInsets.all(128);
+
+  static const TextStyle h1 = TextStyle(fontSize: 64, fontWeight: FontWeight.bold, color: FlutterLatamColors.blueText);
+  static const TextStyle h2 = TextStyle(fontSize: 56, fontWeight: FontWeight.bold, color: FlutterLatamColors.blueText);
+  static const TextStyle h3 = TextStyle(fontSize: 48, fontWeight: FontWeight.bold, color: FlutterLatamColors.blueText);
+  static const TextStyle h4 = TextStyle(fontSize: 40, fontWeight: FontWeight.bold, color: FlutterLatamColors.blueText);
+  static const TextStyle h5 = TextStyle(fontSize: 32, fontWeight: FontWeight.bold, color: FlutterLatamColors.blueText);
+  static const TextStyle h6 = TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: FlutterLatamColors.blueText);
+  static const TextStyle h7 = TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: FlutterLatamColors.blueText);
+
+
 }


### PR DESCRIPTION
- añadir contenido para las paginas de tickets, contacto y schedule (falta la version final y luego la localizacion)
- refactorizacion de la navegacion
- remover el link de CFP e Inicio - redondante ya que tenemos el banner de CFP en el home page y no hay suficiente espacio para ello, ya que faltaba el schedule y la pagina de contacto